### PR TITLE
Use last commit hash, message and author instead of last tag's one

### DIFF
--- a/etc/bricks/version/builder
+++ b/etc/bricks/version/builder
@@ -6,10 +6,10 @@ version() {
     info 'Processing version file'
     pushd /opt/workspace/source
       last_tag=$(git describe --tags --abbrev=0)
-      commit=$(git log -1 --pretty=tformat:'%H'  $last_tag)
-      author=$(git log -1 --pretty=tformat:'%an' $last_tag)
-      message=$(git log -1 --pretty=tformat:'%s'  $last_tag)
-      tag_date=$(git log -1 --pretty=tformat:'%ad' $last_tag)
+      commit=$(git log -1 --pretty=tformat:'%H')
+      author=$(git log -1 --pretty=tformat:'%an')
+      message=$(git log -1 --pretty=tformat:'%s')
+      tag_date=$(git log -1 --pretty=tformat:'%ad')
       
       echo "tag = $last_tag"
       echo "date = $tag_date"


### PR DESCRIPTION
Adding the commit hash of the last git tag is misleading.

You might generate a package with code that is not tagged, and hence corresponds to a different 
commit hash than the one at the resulting json.

I have removed the "$last_tag" from the git log commands which should default to HEAD, yielding
the information about the last commit (which is the one containing the code being packaged)
