### PR TITLE
Escape double quotes when generating version.json

### DIFF
--- a/etc/bricks/version/builder
+++ b/etc/bricks/version/builder
@@ -10,13 +10,19 @@ version() {
       author=$(git log -1 --pretty=tformat:'%an')
       message=$(git log -1 --pretty=tformat:'%s')
       tag_date=$(git log -1 --pretty=tformat:'%ad')
-      
+
+      # Here we remove possible double quotes contained at $message and
+      # $last_tag variables **before** interpolating it in json, or else we
+      # might generate an invalid json!
+      message=${message//\"/}
+      last_tag=${last_tag//\"/}
+
       echo "tag = $last_tag"
       echo "date = $tag_date"
       echo "author = $author"
       echo "commit = $commit"
       echo "message = $message"
-      
+
       generated_version="
         {
            \"tag\": \"$last_tag\",


### PR DESCRIPTION
This PR remove possible double quotes contained at $message and
$last_tag variables **before** interpolating it to `version.json`, or else we
right generate an invalid json!

Actually, commits with double quotes are quite common: merge commits, reverts and such. 
